### PR TITLE
Fix broken highlight, triggered by link with an anchor (`#`)

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,6 +1,9 @@
 .vscode/**
+node_modules/**
+samples/**
 **/*.ts
 **/*.map
 .gitignore
-**/tsconfig.json
-node_modules/**
+.eslintrc.json
+.prettierrc.json
+tsconfig.json

--- a/samples/highlight.sol
+++ b/samples/highlight.sol
@@ -1,0 +1,20 @@
+contract Test {
+    ///#if_succeeds 0==0;
+    /// https://consensys.net/#test
+    /// #if_succeeds
+    ///         1
+    ///             ==
+    ///                 1;
+    /// @custom:scribble #if_succeeds 2 == 2;
+    function some() public {}
+
+    /**#if_succeeds 0==0;
+     * https://consensys.net/#test
+     * #if_succeeds
+     *         1
+     *             ==
+     *                 1;
+     * @custom:scribble #if_succeeds 2 == 2;
+     */
+    function other() public {}
+}

--- a/syntaxes/scribble-inject.tmLanguage.json
+++ b/syntaxes/scribble-inject.tmLanguage.json
@@ -9,7 +9,7 @@
     "repository": {
         "annotation": {
             "contentName": "meta.embedded.annotation.scribble",
-            "begin": "(@custom:scribble\\s+)?#",
+            "begin": "((^|\\G)|((@custom:scribble)?\\s+))#",
             "end": ";",
             "patterns": [
                 {


### PR DESCRIPTION
## Changes
- [x] Fix highlight issue when there is an anchored link in the docblock.
- [x] Added directory `samples` for the samples to verify grammar edge cases.

Regards.